### PR TITLE
Missing package in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "concurrently": "^6.1.0",
     "cors": "^2.8.5",
     "electron-is-dev": "^2.0.0",
     "electron-log": "^4.3.3",


### PR DESCRIPTION
Package "concurrently" is not in package.json resulting in a missing dependency error.

So any user running ```npm i``` with a empty nodejs installation will get an error unless they also run ```npm i concurrently``` in order for the program to work