### PR TITLE
Switch from StreamLabs to StreamElements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ There are many phones around with operating systems and different browsers. It's
 
 1) You can use [Git](https://git-scm.com/downloads) as the CLI but it is not required
 
-2) Install [NodeJS](https://nodejs.org/)
+2) Install [NodeJS 16](https://nodejs.org/en/blog/release/v16.16.0)
 
 4) Install electron globally `npm i -g electron`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elundus-core",
   "description": "Use this simple desktop application to simulate StreamElements text-to-speech (TTS) voice messages for Twitch. Hear how a donation for your favorite streamer sounds like!",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "author": {
     "name": "Sietse Trommelen"
   },

--- a/src/components/tts/form.js
+++ b/src/components/tts/form.js
@@ -87,7 +87,7 @@ class TextToSpeechForm extends React.Component {
         var result = await StreamElementsHelper.GetTtsBlob(voice, text);
         this.setLoading(false);
 
-        if (result.blobUrl != null) {
+        if (result.blobUrl != null || result.blob != null) {
             this.props.dispatch({ type: 'SET_VOICEBLOBURL', data: result.blobUrl });
             this.props.dispatch({ type: 'SET_VOICEBLOB', data: result.blob });
             this.props.dispatch({ type: 'SET_VOICE_TEXT', data: { voice: voice, text: text } });

--- a/src/helpers/streamlabshelper.js
+++ b/src/helpers/streamlabshelper.js
@@ -1,32 +1,28 @@
-export default class StreamElementsHelper {
-    static GetStreamElementsUrl(voice, text) {
-        return `https://api.streamelements.com/kappa/v2/speech?voice=${voice}&text=${encodeURIComponent(text.trim())}`;
-    }
-
+export default class StreamLabsHelper {
     static GetTtsBlob(voice, text) {
 
         if (text === "" || voice === "") {
-            return { blobUrl: null, blob: null, error: { error: 'Oops..', message: 'You need to fill in some text.' } };
+            return { blobUrl: null, error: { error: 'Oops..', message: 'You need to fill in some text.' } };
         }
 
         //Replace invalid characters
         text = text.replaceAll("&", "%26");
         text = text.replaceAll("#", "%23");
 
-        let url = this.GetStreamElementsUrl(voice, text);
+        let url = this.GetInternalApiUrl(voice, text);
 
         return fetch(url)
             .then(async (result) => {
                 if (!result.ok) { throw result }
                 
-                return result.blob();
+                return result.json();
             })
-            .then(data => {
-                if (data == null) {
+            .then(json => {
+                if (json == null) {
                     return { blobUrl: null, blob: null, error: this.GetApiErrorMessage() };
                 }
 
-                return { blobUrl: url, blob: data, error: null };
+                return { blobUrl: json.speakUrl, blob: null, error: null };
             })
             .catch((error) => {                
 


### PR DESCRIPTION
StreamLabs added CloudFlare protection to their API, which resulted in the app not being able to reach the API. To fix this, the API we use to convert text-to-speech will now be StreamElements.